### PR TITLE
Feat/admin

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    images: {
+        domains: ['exwqxpjssemyakuhvalz.supabase.co'],
+    },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.4",
-    "@tanstack/react-query": "^5.59.8",
+    "@tanstack/react-query": "^5.59.9",
     "@tanstack/react-query-devtools": "^5.59.8",
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/react-editor": "^3.2.3",
+    "chart.js": "^4.4.4",
     "next": "14.2.15",
     "react": "^18",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18",
     "zustand": "^5.0.0-rc.2"
   },

--- a/src/app/(admin)/_components/Sidebar.tsx
+++ b/src/app/(admin)/_components/Sidebar.tsx
@@ -1,0 +1,31 @@
+// app/admin/_components/SideBar.tsx
+import Link from "next/link";
+
+const SideBar = () => {
+    return (
+        <div className="w-64 h-screen bg-gray-500 p-5 fixed top-[80px] border-solid border-2 border-black flex flex-col justify-center">
+            <Link href="/admin/board">
+                <div className="h-24 border-solid border-2 border-black text-center text-3xl text-black content-center">
+                    게시글 목록
+                </div>
+            </Link>
+            <Link href="/admin/user">
+                <div className="h-24 border-solid border-2 border-black text-center mt-2 text-3xl text-black content-center">
+                    유저관리
+                </div>
+            </Link>
+            <Link href="/admin/report">
+                <div className="h-24 border-solid border-2 border-black text-center mt-2 text-3xl text-black content-center">
+                    신고된 게시글
+                </div>
+            </Link>
+            <Link href="/admin/chart">
+                <div className="h-24 border-solid border-2 border-black text-center mt-2 text-3xl text-black content-center">
+                    데이터 차트
+                </div>
+            </Link>
+        </div>
+    );
+};
+
+export default SideBar;

--- a/src/app/(admin)/admin/board/_components/BoardSkeleton.tsx
+++ b/src/app/(admin)/admin/board/_components/BoardSkeleton.tsx
@@ -9,7 +9,7 @@ const Skeleton = () => {
                 </div>
             </div>
             <div className="flex space-x-2 self-center">
-                <div className="h-10 bg-green-400 rounded w-20"></div>
+                <div className="h-10 bg-gray-500 rounded w-20"></div>
                 <div className="h-10 bg-red-400 rounded w-20"></div>
             </div>
         </div>

--- a/src/app/(admin)/admin/board/_components/BoardSkeleton.tsx
+++ b/src/app/(admin)/admin/board/_components/BoardSkeleton.tsx
@@ -1,0 +1,19 @@
+const Skeleton = () => {
+    return (
+        <div className="flex justify-between w-[1000px] h-[100px] my-3 bg-gray-300 animate-pulse">
+            <div className="flex flex-col w-[800px]">
+                <div className="h-6 bg-gray-400 rounded mb-2"></div>
+                <div className="flex space-x-2 text-gray-500">
+                    <div className="h-4 bg-gray-400 rounded w-24"></div>
+                    <div className="h-4 bg-gray-400 rounded w-16"></div>
+                </div>
+            </div>
+            <div className="flex space-x-2 self-center">
+                <div className="h-10 bg-green-400 rounded w-20"></div>
+                <div className="h-10 bg-red-400 rounded w-20"></div>
+            </div>
+        </div>
+    );
+};
+
+export default Skeleton;

--- a/src/app/(admin)/admin/board/page.tsx
+++ b/src/app/(admin)/admin/board/page.tsx
@@ -2,20 +2,30 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createClient } from "@/utils/supabase/client";
-import { PostType } from "@/types/Post";
+import { PostType } from "@/app/(admin)/types/Post";
 import { useState } from "react";
 import Skeleton from "./_components/BoardSkeleton";
 
 const pageSize = 5; // 페이지당 보여줄 게시글 수 5개 고정
+const supabase = createClient();
 
 // 게시글을 가져오는 함수
-const fetchPosts = async (page: number): Promise<PostType[]> => {
-    const supabase = createClient();
-    const { data, error } = await supabase
+const fetchPosts = async (page: number, filter: string): Promise<PostType[]> => {
+    let query = supabase
         .from("Post")
-        .select(`* , user_id(*)`)
-        .order("board_id", { ascending: true })
+        .select(`*, user_id(*)`)
         .range((page - 1) * pageSize, page * pageSize - 1);
+
+    // filter에 따라 조건 추가
+    if (filter === "created_at") {
+        query = query.order("created_at", { ascending: false }); // 최신순으로 정렬
+    } else if (filter === "true") {
+        query = query.eq("publicStatus", true).order("created_at", { ascending: false }); // publicStatus가 true인 게시글만
+    } else if (filter === "false") {
+        query = query.eq("publicStatus", false).order("created_at", { ascending: false }); // publicStatus가 false인 게시글만
+    }
+
+    const { data, error } = await query;
 
     if (error) {
         throw new Error(error.message);
@@ -26,7 +36,6 @@ const fetchPosts = async (page: number): Promise<PostType[]> => {
 
 //게시글을 삭제하는 함수
 const deletePost = async (board_id: number) => {
-    const supabase = createClient();
     const { error } = await supabase.from("Post").delete().eq("board_id", board_id); // board_id 기준으로 게시글 삭제
 
     if (error) {
@@ -35,9 +44,16 @@ const deletePost = async (board_id: number) => {
 };
 
 // 총 게시글 수만 가져오기 위한 함수
-const fetchTotalPosts = async (): Promise<number> => {
-    const supabase = createClient();
-    const { count, error } = await supabase.from("Post").select("*", { count: "exact", head: true });
+const fetchTotalPosts = async (filter: string): Promise<number> => {
+    let query = supabase.from("Post").select("*", { count: "exact", head: true });
+
+    if (filter === "true") {
+        query = query.eq("publicStatus", true); // publicStatus가 true인 게시글 수
+    } else if (filter === "false") {
+        query = query.eq("publicStatus", false); // publicStatus가 false인 게시글 수
+    }
+
+    const { count, error } = await query;
 
     if (error) {
         throw new Error(error.message);
@@ -63,44 +79,74 @@ const togglePostVisibility = async ({
 const PostPage = () => {
     const [page, setPage] = useState(1); // 현재 페이지 번호
     const queryClient = useQueryClient();
-
+    const [filter, setFilter] = useState("created_at");
     // 게시글 가져오기
     const {
         data: posts,
         error,
         isLoading
     } = useQuery<PostType[], Error>({
-        queryKey: ["posts", page],
-        queryFn: () => fetchPosts(page) // 페이지 번호 별로 게시글 가져옴
+        queryKey: ["posts", page, filter],
+        queryFn: () => fetchPosts(page, filter)
     });
 
     const deleteMutation = useMutation({
         mutationFn: deletePost,
-        onSuccess: () => {
+        onSuccess: async () => {
             // 삭제 후 게시글 목록을 다시 가져오기 위한 쿼리 무효화
-            queryClient.invalidateQueries({ queryKey: ["posts", page] });
+            queryClient.invalidateQueries({ queryKey: ["posts"] });
+            queryClient.invalidateQueries({ queryKey: ["totalPosts"] });
+
+            const totalPosts = await fetchTotalPosts(filter); // 총 게시글 수 가져오기
+            const totalPages = Math.ceil(totalPosts / pageSize); // 총 페이지 수 계산
+
+            // 현재 페이지가 총 페이지 수보다 크면 이전 페이지로 이동
+            if (page > totalPages && totalPages > 0) {
+                setPage(totalPages);
+            } else if (totalPages === 0) {
+                // 게시글이 없으면 첫 페이지로 이동
+                setPage(1);
+            }
+        }
+    });
+    const toggleVisibilityMutation = useMutation<void, Error, { boardId: number; currentStatus: boolean }>({
+        mutationFn: togglePostVisibility,
+        onSuccess: async () => {
+            queryClient.invalidateQueries({ queryKey: ["posts"] });
+            queryClient.invalidateQueries({ queryKey: ["totalPosts"] });
+
+            const totalPosts = await fetchTotalPosts(filter); // 총 게시글 수 가져오기
+            const totalPages = Math.ceil(totalPosts / pageSize); // 총 페이지 수 계산
+
+            // 현재 페이지가 총 페이지 수보다 크면, 이전 페이지로 이동
+            if (page > totalPages && totalPages > 0) {
+                setPage(totalPages);
+            } else if (totalPages === 0) {
+                // 게시글이 없으면 첫 페이지로 이동
+                setPage(1);
+            }
         }
     });
 
-    const toggleVisibilityMutation = useMutation<void, Error, { boardId: number; currentStatus: boolean }>({
-        mutationFn: togglePostVisibility, // togglePostVisibility 함수
-        onSuccess: () => {
-            // 공개/비공개 변경 후 게시글 목록을 다시 가져오기 위한 쿼리 무효화
-            queryClient.invalidateQueries({ queryKey: ["posts", page] });
-        }
-    });
+    // 필터 변경 시
+    const handleFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        setFilter(e.target.value);
+        setPage(1); // 첫 페이지로 이동
+        queryClient.invalidateQueries({ queryKey: ["posts", 1, e.target.value] }); // 새로운 필터로 게시글 요청
+        queryClient.invalidateQueries({ queryKey: ["totalPosts", e.target.value] }); // 총 게시글 수 요청 무효화
+    };
 
     // 총 게시글 수 가져오기
     const { data: totalPosts } = useQuery<number>({
-        queryKey: ["totalPosts"],
-        queryFn: fetchTotalPosts
+        queryKey: ["totalPosts", filter],
+        queryFn: () => fetchTotalPosts(filter)
     });
 
     const totalPages = totalPosts ? Math.ceil(totalPosts / pageSize) : 1; // 총 페이지 수 계산
 
-    // 현재 페이지를 기준으로 보여줄 페이지 번호의 시작과 끝 계산
+    // 현재 페이지를 기준으로 보여줄 페이지 번호의 시작과 끝번호 계산
     const startPage = Math.floor((page - 1) / 5) * 5 + 1;
-    const endPage = Math.min(startPage + 4, totalPages); // 페이지 번호 5개씩 보여줌
+    const endPage = Math.min(startPage + 4, totalPages);
 
     if (isLoading) {
         return (
@@ -116,34 +162,62 @@ const PostPage = () => {
         return <div>Error: {error.message}</div>;
     }
 
+    const options = [
+        { value: "created_at", label: "최신순" },
+        { value: "true", label: "공개중" },
+        { value: "false", label: "비공개중" }
+    ];
+
     return (
         <>
             <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                <div className="flex items-end text-black mb-1 w-full max-w-[1000px]">
+                    {/* 필터 선택 */}
+                    <select value={filter} onChange={handleFilterChange} className="ml-auto text-center">
+                        {options.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
                 {posts?.map((post) => (
                     <div className="flex justify-between w-[1000px] h-[100px] my-3 bg-white p-4" key={post.board_id}>
                         <div className="flex flex-col">
                             <div className="text-xl w-[800px] text-black">{post.title}</div>
                             <div className="flex space-x-2 text-gray-500">
-                                <div>{post.user_id.user_name}님</div>
-                                <div>{new Date(post.created_at).toLocaleDateString()}</div>
+                                <div>{post.user_id?.user_name}님</div>
+                                <div>{new Date(post.created_at).toISOString().replace("T", " ").slice(0, -5)}</div>
                             </div>
                         </div>
 
                         <div className="flex space-x-2 self-center">
                             <button
                                 className="bg-gray-500 text-white p-2 rounded"
-                                onClick={() =>
-                                    toggleVisibilityMutation.mutate({
-                                        boardId: post.board_id,
-                                        currentStatus: post.publicStatus
-                                    })
-                                }
+                                onClick={() => {
+                                    if (
+                                        window.confirm(
+                                            post.publicStatus
+                                                ? "정말 공개로 전환하시겠습니까?"
+                                                : "정말 비공개로 전환하시겠습니까?"
+                                        )
+                                    ) {
+                                        toggleVisibilityMutation.mutate({
+                                            boardId: post.board_id,
+                                            currentStatus: post.publicStatus
+                                        });
+                                    }
+                                }}
                             >
                                 {post.publicStatus ? "비공개" : "공개"}
                             </button>
                             <button
                                 className="bg-red-500 text-white p-2 rounded"
-                                onClick={() => deleteMutation.mutate(post.board_id)}
+                                onClick={() => {
+                                    if (window.confirm("정말 삭제하시겠습니까?")) {
+                                        deleteMutation.mutate(post.board_id);
+                                    }
+                                }}
                             >
                                 삭제
                             </button>

--- a/src/app/(admin)/admin/board/page.tsx
+++ b/src/app/(admin)/admin/board/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/utils/supabase/client";
+import { PostType } from "@/types/Post";
+import { useState } from "react";
+import Skeleton from "./_components/BoardSkeleton";
+
+const pageSize = 5; // 페이지당 보여줄 게시글 수 5개 고정
+
+// 게시글을 가져오는 함수
+const fetchPosts = async (page: number): Promise<PostType[]> => {
+    const supabase = createClient();
+    const { data, error } = await supabase
+        .from("Post")
+        .select(`* , user_id(*)`)
+        .range((page - 1) * pageSize, page * pageSize - 1);
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return data;
+};
+
+// 총 게시글 수만 가져오기 위한 함수
+const fetchTotalPosts = async (): Promise<number> => {
+    const supabase = createClient();
+    const { count, error } = await supabase.from("Post").select("*", { count: "exact", head: true });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return count || 0;
+};
+
+const PostPage = () => {
+    const [page, setPage] = useState(1); // 현재 페이지 번호
+
+    // 게시글 가져오기
+    const {
+        data: posts,
+        error,
+        isLoading
+    } = useQuery<PostType[], Error>({
+        queryKey: ["posts", page],
+        queryFn: () => fetchPosts(page) // 페이지 번호 별로 게시글 가져옴
+    });
+
+    // 총 게시글 수 가져오기
+    const { data: totalPosts } = useQuery<number>({
+        queryKey: ["totalPosts"],
+        queryFn: fetchTotalPosts
+    });
+
+    const totalPages = totalPosts ? Math.ceil(totalPosts / pageSize) : 1; // 총 페이지 수 계산
+
+    // 현재 페이지를 기준으로 보여줄 페이지 번호의 시작과 끝 계산
+    const startPage = Math.floor((page - 1) / 5) * 5 + 1;
+    const endPage = Math.min(startPage + 4, totalPages); // 페이지 번호 5개씩 보여줌
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                {Array.from({ length: pageSize }).map((_, index) => (
+                    <Skeleton key={index} />
+                ))}
+            </div>
+        );
+    }
+
+    if (error) {
+        return <div>Error: {error.message}</div>;
+    }
+
+    return (
+        <>
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                {posts?.map((post) => (
+                    <div className="flex justify-between w-[1000px] h-[100px] my-3 bg-white p-4" key={post.board_id}>
+                        <div className="flex flex-col">
+                            <div className="text-xl w-[800px] text-black">{post.title}</div>
+                            <div className="flex space-x-2 text-gray-500">
+                                <div>{post.user_id.user_name}님</div>
+                                <div>{new Date(post.created_at).toLocaleDateString()}</div>
+                            </div>
+                        </div>
+
+                        <div className="flex space-x-2 self-center">
+                            <button className="bg-green-500 text-white p-2 rounded">
+                                {post.publicStatus ? "비공개" : "공개"}
+                            </button>
+                            <button className="bg-red-500 text-white p-2 rounded">삭제</button>
+                        </div>
+                    </div>
+                ))}
+
+                {/* 페이지네이션 출력 */}
+                <div className="flex space-x-2 my-5">
+                    <button
+                        disabled={page === 1}
+                        onClick={() => setPage(1)}
+                        className="p-2 bg-blue-500 text-white rounded disabled:opacity-50"
+                    >
+                        &lt;&lt;
+                    </button>
+
+                    <button
+                        disabled={page === 1}
+                        onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                        className="p-2 bg-blue-500 text-white rounded disabled:opacity-50"
+                    >
+                        &lt;
+                    </button>
+                    {Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map((pageNum) => (
+                        <button
+                            key={pageNum}
+                            onClick={() => setPage(pageNum)}
+                            className={`p-2 rounded ${page === pageNum ? "bg-gray-800 text-white" : "bg-gray-300"}`}
+                        >
+                            {pageNum}
+                        </button>
+                    ))}
+
+                    <button
+                        disabled={page === totalPages}
+                        onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                        className="p-2 bg-blue-500 text-white rounded disabled:opacity-50"
+                    >
+                        &gt;
+                    </button>
+                    <button
+                        disabled={page === totalPages}
+                        onClick={() => setPage(totalPages)}
+                        className="p-2 bg-blue-500 text-white rounded disabled:opacity-50"
+                    >
+                        &gt;&gt;
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default PostPage;

--- a/src/app/(admin)/admin/chart/page.tsx
+++ b/src/app/(admin)/admin/chart/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/utils/supabase/client";
+import { Line } from "react-chartjs-2";
+import { UserType } from "../../types/User";
+import { Chart, CategoryScale, LinearScale, LineElement, PointElement, Tooltip, Legend } from "chart.js";
+import { PostType } from "../../types/Post";
+
+const supabase = createClient();
+
+Chart.register(CategoryScale, LinearScale, LineElement, PointElement, Tooltip, Legend);
+
+const fetchUserCounts = async () => {
+    const { data, error } = await supabase
+        .from("Users")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .eq("activate", true);
+
+    if (error) throw new Error(error.message);
+
+    return data as UserType[];
+};
+
+const fetchPosts = async () => {
+    const { data, error } = await supabase
+        .from("Post")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .eq("publicStatus", true);
+    if (error) throw new Error(error.message);
+    return data as PostType[];
+};
+
+const UserPostChart = () => {
+    const {
+        data: users,
+        isLoading,
+        error
+    } = useQuery<UserType[], Error>({
+        queryKey: ["userCounts"],
+        queryFn: fetchUserCounts
+    });
+
+    const { data: posts } = useQuery<PostType[], Error>({
+        queryKey: ["posts"],
+        queryFn: fetchPosts
+    });
+
+    if (isLoading)
+        return (
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                <div className="w-[800px] h-[300px] bg-gray-300"></div>
+            </div>
+        );
+
+    if (error) return <div>Error: {error.message}</div>;
+
+    if (!users) {
+        return <div>데이터가 없습니다.</div>;
+    }
+    if (!posts) {
+        return <div>데이터가 없습니다.</div>;
+    }
+
+    // 날짜별 유저 수 계산
+    const userCountsByDate = users.reduce((acc, user) => {
+        const date = new Date(user.created_at).toISOString().split("T")[0];
+        acc[date] = (acc[date] || 0) + 1;
+        return acc;
+    }, {} as Record<string, number>);
+
+    // 날짜별 게시글 수 계산
+    const postCountsByDate = posts.reduce((acc, post) => {
+        const date = new Date(post.created_at).toISOString().split("T")[0];
+        acc[date] = (acc[date] || 0) + 1;
+        return acc;
+    }, {} as Record<string, number>);
+
+    const chartUserData = {
+        labels: Object.keys(userCountsByDate),
+        datasets: [
+            {
+                label: "일자별 유저 가입 수",
+                data: Object.values(userCountsByDate),
+                fill: false,
+                borderColor: "rgb(75, 192, 192)",
+                tension: 0.1
+            }
+        ]
+    };
+    const chartPostData = {
+        labels: Object.keys(postCountsByDate),
+        datasets: [
+            {
+                label: "일자별 게시글 작성 수",
+                data: Object.values(postCountsByDate),
+                fill: false,
+                borderColor: "rgb(75,192,192)",
+                tension: 0.1
+            }
+        ]
+    };
+
+    return (
+        <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+            <div className="w-[800px]">
+                <Line data={chartUserData} />
+                <div className="w-[800px]">
+                    <Line data={chartPostData} />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UserPostChart;

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,10 @@
+import PostPage from "./board/page";
+
+const page = () => {
+    return (
+        <div>
+            <PostPage />
+        </div>
+    );
+};
+export default page;

--- a/src/app/(admin)/admin/report/_components/ReportSkeleton.tsx
+++ b/src/app/(admin)/admin/report/_components/ReportSkeleton.tsx
@@ -1,0 +1,19 @@
+const Skeleton = () => {
+    return (
+        <div className="flex justify-between w-[1000px] h-[100px] my-3 bg-gray-300 animate-pulse">
+            <div className="flex flex-col w-[800px]">
+                <div className="h-6 bg-gray-400 rounded mb-2"></div>
+                <div className="flex space-x-2 text-gray-500">
+                    <div className="h-4 bg-gray-400 rounded w-24"></div>
+                    <div className="h-4 bg-gray-400 rounded w-16"></div>
+                </div>
+            </div>
+            <div className="flex space-x-2 self-center">
+                <div className="h-10 bg-gray-500 rounded w-20"></div>
+                <div className="h-10 bg-red-400 rounded w-20"></div>
+            </div>
+        </div>
+    );
+};
+
+export default Skeleton;

--- a/src/app/(admin)/admin/report/page.tsx
+++ b/src/app/(admin)/admin/report/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { createClient } from "@/utils/supabase/client";
+import { ReportedPostType } from "../../types/Post";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import Skeleton from "./_components/ReportSkeleton";
+
+const supabase = createClient();
+
+const fetchReportedPosts = async (): Promise<ReportedPostType[]> => {
+    const { data, error } = await supabase.from("Reported_Post").select(`* , user_id(*), board_id(*, user_id(*))`);
+
+    if (error) {
+        throw new Error(error.message);
+    }
+    return data;
+};
+
+const ReportedPostPage = () => {
+    const queryClient = useQueryClient();
+
+    const [isModalOpen, setIsModalOpen] = useState(false); // 모달 열림/닫힘 상태
+    const [selectedReports, setSelectedReports] = useState<ReportedPostType[]>([]); // 선택된 신고 게시글들
+
+    const {
+        data: reportedPosts,
+        error,
+        isLoading
+    } = useQuery<ReportedPostType[], Error>({
+        queryKey: ["reportedPosts"],
+        queryFn: () => fetchReportedPosts()
+    });
+
+    const togglePostVisibility = async ({
+        boardId,
+        currentStatus
+    }: {
+        boardId: number;
+        currentStatus: boolean;
+    }): Promise<void> => {
+        const supabase = createClient();
+        const { error } = await supabase.from("Post").update({ publicStatus: !currentStatus }).eq("board_id", boardId);
+        if (error) {
+            throw new Error(error.message);
+        }
+    };
+
+    const toggleVisibilityMutation = useMutation<void, Error, { boardId: number; currentStatus: boolean }>({
+        mutationFn: togglePostVisibility,
+        onSuccess: async () => {
+            queryClient.invalidateQueries({ queryKey: ["reportedPosts"] });
+        }
+    });
+
+    const deletePost = async (board_id: number) => {
+        await supabase.from("Reported_Post").delete().eq("board_id", board_id);
+        const { error } = await supabase.from("Post").delete().eq("board_id", board_id); // board_id 기준으로 게시글 삭제
+
+        if (error) {
+            throw new Error(error.message);
+        }
+    };
+
+    const deleteMutation = useMutation({
+        mutationFn: deletePost,
+        onSuccess: async () => {
+            // 삭제 후 게시글 목록을 다시 가져오기 위한 쿼리 무효화
+            queryClient.invalidateQueries({ queryKey: ["reportedPosts"] });
+        }
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                {Array.from({ length: 5 }).map((_, index) => (
+                    <Skeleton key={index} />
+                ))}
+            </div>
+        );
+    }
+    if (error) {
+        return <div>Error: {error.message}</div>;
+    }
+
+    // board_id로 그룹화
+    const groupedPosts = reportedPosts?.reduce((acc, post) => {
+        const boardId = post.board_id.board_id;
+
+        if (!acc[boardId]) {
+            acc[boardId] = {
+                ...post.board_id,
+                reportCount: 0 // 신고 건수 초기화
+            };
+        }
+        acc[boardId].reportCount += 1; // 동일한 board_id를 가진 신고 건수 증가
+
+        return acc;
+    }, {} as Record<number, ReportedPostType["board_id"] & { reportCount: number }>);
+
+    // 모달 열기
+    const openModal = (boardId: number) => {
+        // 선택한 게시글의 모든 신고 내역을 필터링
+        const reportsForBoard = reportedPosts?.filter((report) => report.board_id.board_id === boardId) || [];
+        setSelectedReports(reportsForBoard);
+        setIsModalOpen(true);
+    };
+
+    // 모달 닫기
+    const closeModal = () => {
+        setIsModalOpen(false);
+        setSelectedReports([]); // 선택된 신고 목록 초기화
+    };
+
+    return (
+        <>
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                {Object.values(groupedPosts || {}).map((post) => (
+                    <div className="flex justify-between w-[1000px] h-[100px] my-3 bg-white p-4" key={post.board_id}>
+                        <div className="flex flex-col">
+                            <div className="text-xl w-[800px] text-black">{post.title}</div>
+                            <div className="flex space-x-2 text-gray-500">
+                                <div>{post.user_id.user_name}님</div>
+                                <div>{new Date(post.created_at).toISOString().replace("T", " ").slice(0, -5)}</div>
+                                <div
+                                    className="flex rounded-3xl bg-red-600 text-white font-bold w-[150px] justify-center cursor-pointer"
+                                    onClick={() => openModal(post.board_id)}
+                                >
+                                    누적신고된수 : {post.reportCount}건
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="flex space-x-2 self-center">
+                            <button
+                                className="bg-gray-500 text-white p-2 rounded"
+                                onClick={() => {
+                                    if (
+                                        window.confirm(
+                                            post.publicStatus
+                                                ? "정말 공개로 전환하시겠습니까?"
+                                                : "정말 비공개로 전환하시겠습니까?"
+                                        )
+                                    ) {
+                                        toggleVisibilityMutation.mutate({
+                                            boardId: post.board_id,
+                                            currentStatus: post.publicStatus
+                                        });
+                                    }
+                                }}
+                            >
+                                {post.publicStatus ? "비공개" : "공개"}
+                            </button>
+                            <button
+                                className="bg-red-500 text-white p-2 rounded"
+                                onClick={() => {
+                                    if (window.confirm("정말 삭제하시겠습니까?")) {
+                                        deleteMutation.mutate(post.board_id);
+                                    }
+                                }}
+                            >
+                                삭제
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {/* 모달 */}
+            {isModalOpen && selectedReports.length > 0 && (
+                <div className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center">
+                    <div className="bg-white p-6 rounded-lg shadow-lg max-w-lg w-full">
+                        <h2 className="text-2xl mb-4 text-black font-bold text-center">신고 내역</h2>
+                        {selectedReports.map((report) => (
+                            <div key={report.report_id} className="mb-4">
+                                <p className="text-black">신고 사유: {report.report}</p>
+                                <p className="text-black">신고자: {report.user_id.user_name} 님</p>
+                                <hr className="my-2" />
+                            </div>
+                        ))}
+                        <div className="text-center">
+                            <button
+                                className="mt-4 w-[100px] font-bold text-xl bg-white text-black border-solid border-2 border-gray-700 p-2 rounded"
+                                onClick={closeModal}
+                            >
+                                닫기
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default ReportedPostPage;

--- a/src/app/(admin)/admin/user/_components/UserSkeleton.tsx
+++ b/src/app/(admin)/admin/user/_components/UserSkeleton.tsx
@@ -1,0 +1,17 @@
+const Skeleton = () => {
+    return (
+        <div className="col-span-1 border border-solid bg-white border-teal-800 rounded p-4 hover:shadow-lg animate-pulse">
+            <div className="flex justify-center">
+                <div className="h-24 w-24 bg-gray-300 rounded-full"></div>
+            </div>
+            <div className="h-6 bg-gray-400 rounded my-2 w-3/4 mx-auto"></div>
+            <div className="h-4 bg-gray-400 rounded w-1/2 mx-auto my-1"></div>
+            <div className="flex justify-around mt-4">
+                <div className="h-10 bg-gray-500 rounded w-20"></div>
+                <div className="h-10 bg-gray-500 rounded w-20"></div>
+            </div>
+        </div>
+    );
+};
+
+export default Skeleton;

--- a/src/app/(admin)/admin/user/page.tsx
+++ b/src/app/(admin)/admin/user/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { createClient } from "@/utils/supabase/client";
+import { UserType } from "../../types/User";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import Image from "next/image";
+import Skeleton from "./_components/UserSkeleton";
+
+const pageSize = 16; // 페이지당 보여줄 게시글 수 5개 고정
+const supabase = createClient();
+
+const fetchUsers = async (page: number, filter: string): Promise<UserType[]> => {
+    let query = supabase
+        .from("Users")
+        .select(`* `)
+        .range((page - 1) * pageSize, page * pageSize - 1);
+
+    if (filter === "created_at") {
+        query = query.order("created_at", { ascending: false });
+    } else if (filter === "true") {
+        query = query.eq("activate", true).order("created_at", { ascending: false });
+    } else if (filter === "false") {
+        query = query.eq("activate", false).order("created_at", { ascending: false });
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return data;
+};
+
+const fetchTotalUsers = async (filter: string): Promise<number> => {
+    let query = supabase.from("Users").select("*", { count: "exact", head: true });
+
+    if (filter === "true") {
+        query = query.eq("activate", true);
+    } else if (filter === "false") {
+        query = query.eq("activate", false);
+    }
+    const { count, error } = await query;
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    return count || 0;
+};
+
+const toggleUserVisibility = async ({
+    user_id,
+    currentStatus
+}: {
+    user_id: string;
+    currentStatus: boolean;
+}): Promise<void> => {
+    const supabase = createClient();
+    const { error } = await supabase.from("Users").update({ activate: !currentStatus }).eq("id", user_id);
+    if (error) {
+        throw new Error(error.message);
+    }
+};
+
+const UserPage = () => {
+    const [page, setPage] = useState(1); // 현재 페이지 번호
+    const queryClient = useQueryClient();
+    const [filter, setFilter] = useState("created_at");
+
+    const {
+        data: users,
+        error,
+        isLoading
+    } = useQuery<UserType[], Error>({
+        queryKey: ["users", page, filter],
+        queryFn: () => fetchUsers(page, filter) // 페이지 번호 별로 게시글 가져옴
+    });
+
+    // 총 게시글 수 가져오기
+    const { data: totalUsers } = useQuery<number>({
+        queryKey: ["totalUsers", filter],
+        queryFn: () => fetchTotalUsers(filter)
+    });
+
+    const totalPages = totalUsers ? Math.ceil(totalUsers / pageSize) : 1; // 총 페이지 수 계산
+
+    // 현재 페이지를 기준으로 보여줄 페이지 번호의 시작과 끝 계산
+    const startPage = Math.floor((page - 1) / 5) * 5 + 1;
+    const endPage = Math.min(startPage + 4, totalPages); // 페이지 번호 5개씩 보여줌
+
+    const adjustPageAfterMutation = async () => {
+        const updatedTotalUsers = await fetchTotalUsers(filter);
+        const updatedTotalPages = Math.ceil(updatedTotalUsers / pageSize);
+
+        if (page > updatedTotalPages && updatedTotalPages > 0) {
+            setPage(updatedTotalPages); // 마지막 페이지로 이동
+        } else if (updatedTotalPages === 0) {
+            setPage(1); // 사용자 없음 -> 첫 페이지로 이동
+        }
+    };
+    const handleFilterChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const newFilter = e.target.value;
+        setFilter(newFilter);
+
+        // 상태 변경이 완료된 후에 페이지를 1로 설정
+        setPage(1); // 페이지를 1로 변경
+
+        // 페이지 변경 후에 쿼리 무효화
+        queryClient.invalidateQueries({ queryKey: ["users", page, newFilter] });
+        queryClient.invalidateQueries({ queryKey: ["totalUsers", newFilter] });
+    };
+
+    const toggleVisibilityMutation = useMutation<void, Error, { user_id: string; currentStatus: boolean }>({
+        mutationFn: toggleUserVisibility,
+        onSuccess: async () => {
+            await adjustPageAfterMutation(); // 페이지가 변경되면 그에 맞춰 처리
+            queryClient.invalidateQueries({ queryKey: ["users"] }); // 현재 페이지에 대한 쿼리 무효화
+            queryClient.invalidateQueries({ queryKey: ["totalUsers"] });
+        }
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                <div className="grid grid-cols-4 gap-4">
+                    {Array.from({ length: pageSize }).map((_, index) => (
+                        <Skeleton key={index} />
+                    ))}
+                </div>
+            </div>
+        );
+    }
+    if (error) return <div>Error: {error.message}</div>;
+
+    const options = [
+        { value: "created_at", label: "최신순" },
+        { value: "true", label: "활성화중" },
+        { value: "false", label: "비활성화중" }
+    ];
+
+    return (
+        <>
+            <div className="flex justify-center items-center flex-col min-h-screen bg-gray-100">
+                <div className="flex items-end text-black mb-3 w-full max-w-[850px]">
+                    {/* 필터 선택 */}
+                    <select value={filter} onChange={handleFilterChange} className="ml-auto text-center">
+                        {options.map((option) => (
+                            <option key={option.value} value={option.value} className="">
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="grid grid-cols-4 gap-4">
+                    {users?.map((user) => (
+                        <div
+                            key={user.id}
+                            className="border border-solid bg-white border-teal-800 rounded p-4 hover:shadow-lg"
+                        >
+                            <div className="flex justify-center">
+                                <Image
+                                    src={user.profile_url}
+                                    alt="profile"
+                                    className="rounded-full"
+                                    width={100}
+                                    height={100}
+                                />
+                            </div>
+                            <div className="text-center">
+                                <div className="font-bold text-black text-xl">{user.user_name}님</div>
+                            </div>
+                            <div className="text-center text-black">
+                                <div>{user.email}</div>
+                            </div>
+                            <div className="flex justify-around">
+                                {user.activate ? (
+                                    <button
+                                        className="w-20 bg-red-400 font-bold"
+                                        onClick={() => {
+                                            if (window.confirm("정말 탈퇴하시겠습니까?")) {
+                                                toggleVisibilityMutation.mutate({
+                                                    user_id: user.id,
+                                                    currentStatus: user.activate
+                                                });
+                                            }
+                                        }}
+                                    >
+                                        {user.activate ? "탈퇴" : ""}
+                                    </button>
+                                ) : (
+                                    ""
+                                )}
+
+                                <button
+                                    className="w-20 bg-gray-400 font-bold"
+                                    onClick={() => {
+                                        if (
+                                            window.confirm(
+                                                user.activate
+                                                    ? "정말 비활성화 하시겠습니까?"
+                                                    : "정말 활성화 하시겠습니까?"
+                                            )
+                                        ) {
+                                            toggleVisibilityMutation.mutate({
+                                                user_id: user.id,
+                                                currentStatus: user.activate
+                                            });
+                                        }
+                                    }}
+                                >
+                                    {user.activate ? "비활성화" : "활성화"}
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+                <div className="flex space-x-2 my-5">
+                    <button
+                        disabled={page === 1}
+                        onClick={() => setPage(1)}
+                        className="p-2 bg-gray-500 text-white rounded disabled:opacity-50"
+                    >
+                        &lt;&lt;
+                    </button>
+
+                    <button
+                        disabled={page === 1}
+                        onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                        className="p-2 bg-gray-500 text-white rounded disabled:opacity-50"
+                    >
+                        &lt;
+                    </button>
+                    {Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map((pageNum) => (
+                        <button
+                            key={pageNum}
+                            onClick={() => setPage(pageNum)}
+                            className={`p-2 rounded ${page === pageNum ? "bg-gray-800 text-white" : "bg-gray-300"}`}
+                        >
+                            {pageNum}
+                        </button>
+                    ))}
+
+                    <button
+                        disabled={page === totalPages}
+                        onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+                        className="p-2 bg-gray-500 text-white rounded disabled:opacity-50"
+                    >
+                        &gt;
+                    </button>
+                    <button
+                        disabled={page === totalPages}
+                        onClick={() => setPage(totalPages)}
+                        className="p-2 bg-gray-500 text-white rounded disabled:opacity-50"
+                    >
+                        &gt;&gt;
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+};
+export default UserPage;

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,18 @@
+// app/admin/layout.tsx
+import { ReactNode } from "react";
+import SideBar from "./_components/Sidebar";
+
+type LayoutProps = {
+    children: ReactNode;
+};
+
+const AdminLayout = ({ children }: LayoutProps) => {
+    return (
+        <div className="flex">
+            <SideBar />
+            <div className="ml-64 mt-[80px] flex-grow ">{children}</div>
+        </div>
+    );
+};
+
+export default AdminLayout;

--- a/src/app/(admin)/types/Post.ts
+++ b/src/app/(admin)/types/Post.ts
@@ -1,0 +1,49 @@
+export type PostType = {
+    board_id: number;
+    title: string;
+    content: string;
+    img_url?: string;
+    publicStatus: boolean;
+    created_at: string;
+    user_id: {
+        id: string;
+        email: string;
+        profile_url: string;
+        user_name: string;
+        created_at: string;
+        admin?: boolean;
+        activate: boolean;
+    };
+};
+
+export type ReportedPostType = {
+    report_id: number;
+    report: string;
+    created_at: string;
+    board_id: {
+        board_id: number;
+        title: string;
+        content: string;
+        img_url?: string;
+        publicStatus: boolean;
+        created_at: string;
+        user_id: {
+            id: string;
+            email: string;
+            profile_url: string;
+            user_name: string;
+            created_at: string;
+            admin?: boolean;
+            activate: boolean;
+        };
+    };
+    user_id: {
+        id: string;
+        email: string;
+        profile_url: string;
+        user_name: string;
+        created_at: string;
+        admin?: boolean;
+        activate: boolean;
+    };
+};

--- a/src/app/(admin)/types/User.ts
+++ b/src/app/(admin)/types/User.ts
@@ -1,0 +1,8 @@
+export type UserType = {
+    id: string;
+    user_name: string;
+    profile_url: string;
+    email: string;
+    activate: boolean;
+    created_at: string;
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import Navibar from "./components/Navibar";
 import Providers from "./providers";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const geistSans = localFont({
     src: "./fonts/GeistVF.woff",
@@ -28,8 +29,11 @@ export default function RootLayout({
     return (
         <html lang="ko">
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-                <Navibar />
-                <Providers>{children}</Providers>
+                <Providers>
+                    <Navibar />
+                    {children}
+                    <ReactQueryDevtools initialIsOpen={false} />
+                </Providers>
             </body>
         </html>
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import Navibar from "./components/Navibar";
+import Providers from "./providers";
 
 const geistSans = localFont({
     src: "./fonts/GeistVF.woff",
@@ -25,10 +26,10 @@ export default function RootLayout({
     children: React.ReactNode;
 }>) {
     return (
-        <html lang="en">
+        <html lang="ko">
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
                 <Navibar />
-                {children}
+                <Providers>{children}</Providers>
             </body>
         </html>
     );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,40 @@
+// In Next.js, this file would be called: app/providers.jsx
+"use client";
+
+// Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
+import { isServer, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+function makeQueryClient() {
+    return new QueryClient({
+        defaultOptions: {
+            queries: {
+                // With SSR, we usually want to set some default staleTime
+                // above 0 to avoid refetching immediately on the client
+                staleTime: 60 * 1000
+            }
+        }
+    });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+    if (isServer) {
+        // Server: always make a new query client
+        return makeQueryClient();
+    } else {
+        // Browser: make a new query client if we don't already have one
+        // This is very important, so we don't re-make a new client if React
+        // suspends during the initial render. This may not be needed if we
+        // have a suspense boundary BELOW the creation of the query client
+        if (!browserQueryClient) browserQueryClient = makeQueryClient();
+        return browserQueryClient;
+    }
+}
+
+// Providers.jsx
+export default function Providers({ children }: { children: React.ReactNode }) {
+    const queryClient = getQueryClient(); // QueryClient 가져오기
+
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -15,7 +15,7 @@ export async function updateSession(request: NextRequest) {
                     return request.cookies.getAll();
                 },
                 setAll(cookiesToSet) {
-                    cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value));
+                    cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
                     supabaseResponse = NextResponse.next({
                         request
                     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
+  integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
+
 "@next/env@14.2.15":
   version "14.2.15"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.15.tgz#06d984e37e670d93ddd6790af1844aeb935f332f"
@@ -277,10 +282,10 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
-"@tanstack/query-core@5.59.6":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.59.6.tgz#96bf2cc00f2bbd111def52134f10d50e6c1235dd"
-  integrity sha512-g58YTHe4ClRrjJ50GY9fas/0zARJVozY0Hs+hcSBOmwZaeKY+to0/LX8wKnnH/EJiLYcC1sHmE11CAS3ncfZBg==
+"@tanstack/query-core@5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.59.9.tgz#8a41137e6693cd0bca3a6e3eb802d119c1352900"
+  integrity sha512-vFGnblfJOKlOPyTR5M0ohWKb/03eGubh5KuGyzsDfc7VQ6F0nsB75kQIoLpwp3Wfj6fKv0wGoTUX8BsIfhxDfw==
 
 "@tanstack/query-devtools@5.58.0":
   version "5.58.0"
@@ -294,12 +299,12 @@
   dependencies:
     "@tanstack/query-devtools" "5.58.0"
 
-"@tanstack/react-query@^5.59.8":
-  version "5.59.8"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.59.8.tgz#ae00d67235be9fb6ce79779faa84228e69676041"
-  integrity sha512-jkvObpbjBL6P/PHFIjvNGG19XyhI8sjP6/Mw7CbmgT6SAps/5fZY5pxDicRwAt1YGCiEQvwrJQ6IdbZ8j5CVfw==
+"@tanstack/react-query@^5.59.9":
+  version "5.59.9"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.59.9.tgz#d4e40f1ac4106330bcc4e85a77914ccca8beee21"
+  integrity sha512-g2cbiw/ZIIrnUaQqhGtarTAsuLdKDNLtY5HNfRHVWY9kHDj96M4qs4ygJxHc119tPQpzZe4i9W7d2Gc2Gvng2A==
   dependencies:
-    "@tanstack/query-core" "5.59.6"
+    "@tanstack/query-core" "5.59.9"
 
 "@toast-ui/editor@^3.2.2":
   version "3.2.2"
@@ -714,6 +719,13 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chart.js@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.4.4.tgz#b682d2e7249f7a0cbb1b1d31c840266ae9db64b7"
+  integrity sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 chokidar@^3.5.3:
   version "3.6.0"
@@ -2347,6 +2359,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-chartjs-2@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz#43c1e3549071c00a1a083ecbd26c1ad34d385f5d"
+  integrity sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==
 
 react-dom@^18:
   version "18.3.1"


### PR DESCRIPTION
1. 관리자 게시글 목록 ( 게시글 목록 출력 , 공개/비공개 여부 변경 , 삭제 , 페이지네이션, 필터를통한 리스트(최신순, 공개중 ,비공개중) , 스켈레톤UI 적용

2. 관리자 유저관리 (유저 목록 출력 , 이용제한가능 , 탈퇴(soft delete로 이용제한으로 설정) , 필터를 통한 리스트(최신 가입자순 , 활성화 , 비활성화 순) , 스켈레톤 UI 적용

3. 신고된 게시글 출력 / 누적신고된수 / 공개비공개 여부 수정 / 삭제(신고된내용과 게시글삭제)
페이지네이션과 필터를 적용하고 싶었지만 DB설계상 어려움이 있어 적용하지 못함
필터같은 경우 최신순 정렬은 가능했지만 누적 신고된 수로 정렬하는것에 있어 현재 테이블은 해당게시글의 신고된 수를 가지고 있는것이 없고 board_id가 같은것끼리 count하여 누적신고된 수를 출력해야해서 필터기능을 못함..
페이지네이션 같은경우 수파베이스에서 5개씩 가져와서 board_id가 같은것이 있으면 출력이 안되게 했더니 한 페이지당 5개가 출력이 안되는 문제가 있었고 전체 데이터를 가져와서 board_id가 다를것만 출력하고 페이지네이션을 하려하였으나 어려움이 있어.. 기능을 제외함(신고된 게시글(테이블) →  신고내용(테이블) 처럼 중간테이블을 하나 만들면 좀 편해질거 같은데 이제와서 테이블 변경은 늦은거같은 느낌…)

4. 데이터 차트 출력 ( 일자별 유저 가입 수 , 일자별 게시글 작성 수)
https://www.chartjs.org/ charjs라이브러리를 이용한 차트 만들기